### PR TITLE
Fixing coverage and making tests reentrant, v1.1.6

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -9,7 +9,7 @@
     "json"
   ],
   "exclude": ["**/*/test*", "test/*", "coverage/*", ".eslintrc.js"],
-  "report-dir": "./coverage/node/",
+  "report-dir": "./coverage/",
   "all": "true"
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
-  - "v12.16.1"
+  - "v12.16.2"
 install:
   - npm install
 script:
   - npm run lint
+  - npm run test
 after_script:
   - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,4 @@ install:
   - npm install
 script:
   - npm run lint
-  - npm run test
-after_script:
   - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+cache:
+  npm: false
 node_js:
   - "v12.16.2"
 install:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@lorena-ssi/did-resolver": "^0.2.0",
     "@lorena-ssi/matrix-lib": "^1.0.9",
     "@lorena-ssi/substrate-lib": "^2.1.3",
-    "@lorena-ssi/wallet-lib": "^1.0.12",
+    "@lorena-ssi/wallet-lib": "^1.1.0",
     "@lorena-ssi/zenroom-lib": "^1.5.0",
     "debug": "^4.1.1",
     "esm": "^3.2.25"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lorena-ssi/lorena-sdk",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Lorena SDK",
   "author": "Alex Puig <alex@caelumlabs.com>",
   "license": "MIT",

--- a/test/lorena-test.js
+++ b/test/lorena-test.js
@@ -17,8 +17,16 @@ const lorenaKeys = [
 ]
 
 describe('Lorena API', function () {
-  let lorena
-  const wallet = new Wallet('test')
+  let lorena, wallet
+  const password = 'test'
+
+  it('should prepare the wallet', async () => {
+    wallet = new Wallet('lorena-sdk-test')
+    await wallet.delete()
+    const result = await wallet.unlock(password)
+    expect(result).to.be.false
+    await wallet.lock(password)
+  })
 
   it('should construct a Lorena class', async () => {
     lorena = new Lorena(wallet)
@@ -43,14 +51,14 @@ describe('Lorena API', function () {
     lorena.on('unlocked', () => {
       done()
     })
-    lorena.unlock('test')
+    lorena.unlock(password)
   })
 
   it('should lock wallet', (done) => {
     lorena.on('locked', () => {
       done()
     })
-    lorena.lock('test')
+    lorena.lock(password)
   })
 
   it('should have these private methods', () => {


### PR DESCRIPTION
* Fix coverage
* Use a unique wallet name
* Delete wallet at start of test so it is reentrant