### PR TITLE
update dependencies, fix function signature of verifyCredential

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lorena-ssi/lorena-sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Lorena SDK",
   "author": "Alex Puig <alex@caelumlabs.com>",
   "license": "MIT",
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/lorena-ssi/lorena-sdk#readme",
   "dependencies": {
     "@lorena-ssi/credential-lib": "^1.1.2",
-    "@lorena-ssi/did-resolver": "^0.4.2",
+    "@lorena-ssi/did-resolver": "^0.4.3",
     "@lorena-ssi/matrix-lib": "^1.0.13",
     "@lorena-ssi/wallet-lib": "1.1.5",
     "@lorena-ssi/zenroom-lib": "1.5.3",
@@ -42,7 +42,7 @@
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-chai-friendly": "^0.6.0",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jsdoc": "^25.2.0",
+    "eslint-plugin-jsdoc": "^25.4.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -587,7 +587,7 @@ export default class Lorena extends EventEmitter {
    * @returns {Promise} of success (JSON) or failure (false)
    */
   /* istanbul ignore next */
-  validateCertificate (json) {
+  async validateCertificate (json) {
     debug('validateCertificate() deprecated: use verifyCredential()')
     return this.verifyCredential(json)
   }
@@ -598,7 +598,7 @@ export default class Lorena extends EventEmitter {
    * @param {*} json of credential to verify
    * @returns {Promise} of success (JSON) or failure (false)
    */
-  verifyCredential (json) {
+  async verifyCredential (json) {
     return new Promise((resolve) => {
       try {
         const credential = JSON.parse(json)


### PR DESCRIPTION
`verifyCredential()` always returns a Promise, so it should be `async` to avoid warnings in vscode